### PR TITLE
대본 작성 페이지 레이아웃 및 기능 구현

### DIFF
--- a/app/(route)/community/_components/EditorToolBar.tsx
+++ b/app/(route)/community/_components/EditorToolBar.tsx
@@ -2,7 +2,7 @@ import { FONT_SIZE } from "../_constants/constants";
 
 export default function EditorToolBar() {
   return (
-    <div id="toolbar" className="ql-toolbar">
+    <div id="toolbar" className="ql-toolbar bg-white">
       <span className="ql-formats w-16">
         <select className="ql-size" defaultValue="16px">
           {FONT_SIZE.map((el, index) => (

--- a/app/(route)/community/_components/TextEditor.tsx
+++ b/app/(route)/community/_components/TextEditor.tsx
@@ -1,6 +1,5 @@
 // 이후 다른 곳에서 사용하게 되면 상위 _components 폴더로 옮겨주세요
 
-import DOMPurify from "isomorphic-dompurify";
 import dynamic from "next/dynamic";
 import "react-quill/dist/quill.snow.css";
 import EditorToolBar from "./EditorToolBar";
@@ -18,10 +17,12 @@ const TextEditor = React.memo(
     width,
     height,
     onChange,
+    defaultValue,
   }: {
     width: string;
     height: string;
     onChange: (text: string) => void;
+    defaultValue?: string;
   }) => {
     // ReactQuill을 dynamic을 이용하여 서버에서
     // import 되지 않고 브라우저 내에서만 실행되도록 함
@@ -113,9 +114,10 @@ const TextEditor = React.memo(
           forwardedRef={ref}
           theme="snow"
           // toolbar의 높이 : 43px
-          className={`react-quill w-full h-[calc(100%-43px)]`}
+          className={`react-quill w-full h-[calc(100%-43px)] bg-white`}
           onChange={onTextChange}
           modules={modules}
+          defaultValue={defaultValue}
         />
       </section>
     );

--- a/app/(route)/script/_components/CreateScript.tsx
+++ b/app/(route)/script/_components/CreateScript.tsx
@@ -1,0 +1,63 @@
+import { useCallback, useState } from "react";
+import { CreateScriptProps, ScriptForm } from "../_interfaces/interfaces";
+import TextEditor from "../../community/_components/TextEditor";
+import DropDown from "../../../_components/DropDown";
+import { useForm } from "react-hook-form";
+
+export default function CreateScript({
+  defaultValue,
+  projectList,
+  onSubmit,
+}: CreateScriptProps) {
+  // 드롭다운 관련 state 선언
+  const [isDropdownOpen, setIsDropdownOpen] = useState(false);
+  const [selectedProject, setSelectedProject] = useState("");
+
+  // 대본 form 데이터 생성
+  const { register, handleSubmit, setValue } = useForm<ScriptForm>();
+  const onValid = (data: ScriptForm) => {
+    // 제목, 내용, 프로젝트 선택 시 저장 가능
+    if (data.fileName !== "" && data.fileContent !== "" && data.projectSeq) {
+      onSubmit(data);
+    }
+  };
+
+  return (
+    <form onSubmit={handleSubmit(onValid)} className="section-container">
+      <span className="title-text">대본 작성</span>
+      <input
+        {...register("fileName")}
+        className="text-input"
+        placeholder="저장할 대본의 제목을 작성해 주세요"
+      />
+      <TextEditor
+        defaultValue={defaultValue}
+        onChange={useCallback(
+          (text) => {
+            setValue("fileContent", text);
+          },
+          [setValue]
+        )}
+        height="500px"
+        width="100%"
+      />
+      <DropDown
+        currentValue={selectedProject}
+        isOpened={isDropdownOpen}
+        onDropDownClick={() => setIsDropdownOpen((prev) => !prev)}
+        onSelectionClick={(selected) => {
+          setSelectedProject(selected);
+          setValue(
+            "projectSeq",
+            projectList.filter((el) => el.project === selected)[0].id
+          );
+        }}
+        placeholder="저장할 프로젝트를 선택해 주세요"
+        selectionList={projectList.map((el) => el.project)}
+      />
+      <button className="primary-script-button" type="submit">
+        저장하기
+      </button>
+    </form>
+  );
+}

--- a/app/(route)/script/_components/CreateScriptDraft.tsx
+++ b/app/(route)/script/_components/CreateScriptDraft.tsx
@@ -1,0 +1,28 @@
+import { useForm } from "react-hook-form";
+import { CreateScriptDraftProps } from "../_interfaces/interfaces";
+
+export default function CreateScriptDraft({
+  onSubmit,
+}: CreateScriptDraftProps) {
+  // 대본 초안 form 데이터 생성
+  const { register, handleSubmit } = useForm<{ draft: string }>();
+  const onValid = ({ draft }) => {
+    // 초안 내용 작성 시 생성 가능
+    if (draft !== "") {
+      onSubmit(draft);
+    }
+  };
+  return (
+    <form onSubmit={handleSubmit(onValid)} className="section-container">
+      <span className="title-text">대본 초안 작성</span>
+      <textarea
+        {...register("draft")}
+        className="text-input h-[200px]"
+        placeholder="발표의 주제 및 핵심내용을 포함하여 입력해 주세요"
+      />
+      <button className="default-script-button" type="submit">
+        생성하기
+      </button>
+    </form>
+  );
+}

--- a/app/(route)/script/_constants/constants.ts
+++ b/app/(route)/script/_constants/constants.ts
@@ -1,0 +1,9 @@
+import { Project } from "../_interfaces/interfaces";
+
+export const DUMMY_PROJECT_LIST: Project[] = [
+  { id: 1, project: "프로젝트명1" },
+  { id: 2, project: "프로젝트명2" },
+  { id: 3, project: "프로젝트명3" },
+  { id: 4, project: "프로젝트명4" },
+  { id: 5, project: "프로젝트명5" },
+];

--- a/app/(route)/script/_interfaces/interfaces.ts
+++ b/app/(route)/script/_interfaces/interfaces.ts
@@ -1,0 +1,20 @@
+export interface Project {
+  id: number;
+  project: string;
+}
+
+export interface CreateScriptDraftProps {
+  onSubmit: (draft: string) => void;
+}
+
+export interface CreateScriptProps {
+  defaultValue?: string;
+  projectList: Project[];
+  onSubmit: (data: ScriptForm) => void;
+}
+
+export interface ScriptForm {
+  projectSeq: number;
+  fileName: string;
+  fileContent: string;
+}

--- a/app/(route)/script/page.tsx
+++ b/app/(route)/script/page.tsx
@@ -1,0 +1,81 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import TopBar from "../../_components/TopBar/TopBar";
+import Footer from "../_components/Footer";
+import api from "../../_api/config";
+import CreateScriptDraft from "./_components/CreateScriptDraft";
+import CreateScript from "./_components/CreateScript";
+import { Project } from "./_interfaces/interfaces";
+import { DUMMY_PROJECT_LIST } from "./_constants/constants";
+
+export default function ScriptPage() {
+  // token 가져오기
+  const [token, setToken] = useState("");
+  useEffect(() => {
+    if (typeof window !== "undefined") {
+      // 로그인(토큰 저장) 구현 후 수정 필요
+      const storedToken = localStorage.getItem("token");
+      storedToken && setToken(storedToken); // Bearer 제거
+    }
+  }, []);
+
+  // 토큰으로 프로젝트 목록 불러오기
+  const [projectList, setProjectList] = useState<Project[]>();
+  useEffect(() => {
+    if (token !== "") {
+      api
+        .get("/api/script-service/projects", {
+          headers: { Authorization: token },
+          params: { Authorization: token },
+        })
+        .then((res) => {
+          // 이후 res에서 가져온 데이터로 대체 필요
+          setProjectList(res.data);
+        });
+      // 403 에러
+      // parameters에 Authorization에 뭘 넣어야 하는지 모르겠음
+      // 위의 headers를 없애면 401 에러가 나오는 것을 보아
+      // headers의 토큰으로 JWT 인증까지는 되는 것으로 판단됨
+      // (아래의 초안 GPT 작성은 멀쩡하게 됨)
+    }
+  }, [token]);
+
+  const [defaultValue, setDefaultValue] = useState("");
+  const handleDraft = async (draft: string) => {
+    try {
+      const response = await api.post(
+        "/api/script-service/script/ai",
+        { content: draft },
+        { headers: { Authorization: token } }
+      );
+      console.log(response.data);
+
+      // GPT 응답 시 아래 대본 작성 부분에 초안 입력
+      setDefaultValue(response.data);
+    } catch (err) {
+      console.log(err);
+    }
+  };
+
+  return (
+    <>
+      <TopBar screen="lg" />
+      <div className="w-full flex justify-center pt-[72px] px-4 bg-primary-0">
+        <div className="w-full max-w-[1200px] flex flex-col py-[60px] gap-[60px]">
+          {/* 대본 초안 작성 */}
+          <CreateScriptDraft onSubmit={handleDraft} />
+          {/* 대본 작성 */}
+          <CreateScript
+            defaultValue={defaultValue}
+            projectList={DUMMY_PROJECT_LIST}
+            onSubmit={(data) => {
+              console.log(data);
+            }}
+          />
+        </div>
+      </div>
+      <Footer />
+    </>
+  );
+}

--- a/app/(route)/script/page.tsx
+++ b/app/(route)/script/page.tsx
@@ -6,7 +6,7 @@ import Footer from "../_components/Footer";
 import api from "../../_api/config";
 import CreateScriptDraft from "./_components/CreateScriptDraft";
 import CreateScript from "./_components/CreateScript";
-import { Project } from "./_interfaces/interfaces";
+import { Project, ScriptForm } from "./_interfaces/interfaces";
 import { DUMMY_PROJECT_LIST } from "./_constants/constants";
 
 export default function ScriptPage() {
@@ -58,6 +58,25 @@ export default function ScriptPage() {
     }
   };
 
+  const handleScript = async (data: ScriptForm) => {
+    try {
+      // 지금 data.projectSeq은 존재하는 프로젝트의 id값
+      const response = await api.post(
+        `/api/script-service/script/${data.projectSeq}`,
+        {
+          fileName: data.fileName,
+          fileContent: data.fileContent,
+        },
+        {
+          headers: { Authorization: token },
+        }
+      );
+      console.log(response);
+    } catch (err) {
+      console.log(err);
+    }
+  };
+
   return (
     <>
       <TopBar screen="lg" />
@@ -69,9 +88,7 @@ export default function ScriptPage() {
           <CreateScript
             defaultValue={defaultValue}
             projectList={DUMMY_PROJECT_LIST}
-            onSubmit={(data) => {
-              console.log(data);
-            }}
+            onSubmit={handleScript}
           />
         </div>
       </div>

--- a/package-lock.json
+++ b/package-lock.json
@@ -5382,6 +5382,126 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/@next/swc-darwin-x64": {
+      "version": "14.2.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-14.2.4.tgz",
+      "integrity": "sha512-QVadW73sWIO6E2VroyUjuAxhWLZWEpiFqHdZdoQ/AMpN9YWGuHV8t2rChr0ahy+irKX5mlDU7OY68k3n4tAZTg==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-arm64-gnu": {
+      "version": "14.2.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-14.2.4.tgz",
+      "integrity": "sha512-KT6GUrb3oyCfcfJ+WliXuJnD6pCpZiosx2X3k66HLR+DMoilRb76LpWPGb4tZprawTtcnyrv75ElD6VncVamUQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-arm64-musl": {
+      "version": "14.2.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-14.2.4.tgz",
+      "integrity": "sha512-Alv8/XGSs/ytwQcbCHwze1HmiIkIVhDHYLjczSVrf0Wi2MvKn/blt7+S6FJitj3yTlMwMxII1gIJ9WepI4aZ/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-x64-gnu": {
+      "version": "14.2.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-14.2.4.tgz",
+      "integrity": "sha512-ze0ShQDBPCqxLImzw4sCdfnB3lRmN3qGMB2GWDRlq5Wqy4G36pxtNOo2usu/Nm9+V2Rh/QQnrRc2l94kYFXO6Q==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-x64-musl": {
+      "version": "14.2.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-14.2.4.tgz",
+      "integrity": "sha512-8dwC0UJoc6fC7PX70csdaznVMNr16hQrTDAMPvLPloazlcaWfdPogq+UpZX6Drqb1OBlwowz8iG7WR0Tzk/diQ==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-win32-arm64-msvc": {
+      "version": "14.2.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-14.2.4.tgz",
+      "integrity": "sha512-jxyg67NbEWkDyvM+O8UDbPAyYRZqGLQDTPwvrBBeOSyVWW/jFQkQKQ70JDqDSYg1ZDdl+E3nkbFbq8xM8E9x8A==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-win32-ia32-msvc": {
+      "version": "14.2.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-14.2.4.tgz",
+      "integrity": "sha512-twrmN753hjXRdcrZmZttb/m5xaCBFa48Dt3FbeEItpJArxriYDunWxJn+QFXdJ3hPkm4u7CKxncVvnmgQMY1ag==",
+      "cpu": [
+        "ia32"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-win32-x64-msvc": {
+      "version": "14.2.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-14.2.4.tgz",
+      "integrity": "sha512-tkLrjBzqFTP8DVrAAQmZelEahfR9OxWpFR++vAI9FBhCiIxtwHwBHC23SBHCTURBtwB4kc/x44imVOnkKGNVGg==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
     }
   }
 }

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -136,4 +136,21 @@ body {
   .ql-size > span > span {
     @apply text-center;
   }
+
+  /* 대본 작성 */
+  .text-input {
+    @apply w-full resize-none outline-none px-6 py-3 rounded-lg placeholder:text-gray-4;
+  }
+  .section-container {
+    @apply w-full flex flex-col gap-3;
+  }
+  .script-button {
+    @apply self-end w-fit px-6 py-3 font-semibold rounded-lg;
+  }
+  .default-script-button {
+    @apply script-button bg-white text-gray-4;
+  }
+  .primary-script-button {
+    @apply script-button bg-primary-1 text-white;
+  }
 }


### PR DESCRIPTION
- 제목 : 대본 작성 페이지 레이아웃 및 기능 구현

<br/>

## 🔎 작업 내용

- 어떤 변경 사항이 있었나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [x] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

<br/>

## 이미지 첨부

<br/>

## 🔧 앞으로의 과제

- 프로젝트 불러오기
- 저장한 후의 페이지 라우팅 (전체 프로젝트 목록 페이지로 보낼지, 해당 프로젝트 내 대본 확인 페이지로 보낼지)

  <br/>

## ➕ 추가 코멘트
(10.22 윤장호)
GET : 프로젝트 조회 API (/api/script-service/projects)의 작동 방식을 이해하지 못 해 구현하지 못했음(상세 내용은 해당 부분 코드 주석 확인)
현재 해당 부분만 더미 데이터로 작동하며, 이 외의 기능들은 API와 연동되어 정상적으로 작동하는 것을 확인함

<br/>
